### PR TITLE
terminal click to copy selected text

### DIFF
--- a/src/lib/components/terminal/Terminal.svelte
+++ b/src/lib/components/terminal/Terminal.svelte
@@ -245,6 +245,15 @@
 			}
 			termEl.addEventListener('wheel', onWheel, { passive: false });
 
+			// Click to copy: if text is selected, clicking copies it
+			function onClick(e: MouseEvent) {
+				if (term.hasSelection()) {
+					navigator.clipboard.writeText(term.getSelection());
+					term.clearSelection();
+				}
+			}
+			termEl.addEventListener('click', onClick);
+
 			terminal = term;
 			fitAddon = fit;
 
@@ -271,6 +280,9 @@
 			unlistenData?.();
 			unlistenExit?.();
 			resizeObserver?.disconnect();
+			termEl.removeEventListener('contextmenu', onContextMenu);
+			termEl.removeEventListener('wheel', onWheel);
+			termEl.removeEventListener('click', onClick);
 			term.dispose();
 			terminal = undefined;
 			fitAddon = undefined;


### PR DESCRIPTION
Copy highlighted text to clipboard on mouse click. Selection is cleared after copy. Also adds proper cleanup for event listeners.