### PR TITLE
Fix #25: vault password could never be set or changed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3914,6 +3914,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +3930,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4833,6 +4843,7 @@ dependencies = [
  "keyring",
  "libsql",
  "mlua",
+ "openssl-sys",
  "portable-pty",
  "rand 0.8.5",
  "regex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
@@ -26,6 +27,10 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
+
+# Transitive dep openssl-sys (via ssh2-config -> git2 -> libgit2-sys) needs
+# dev headers. Vendored builds without system OpenSSL.
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 # SSH
 russh = { version = "0.46", default-features = false }

--- a/src-tauri/src/ipc/credential_commands.rs
+++ b/src-tauri/src/ipc/credential_commands.rs
@@ -13,7 +13,10 @@ const CREDENTIALS_VAULT_NAME: &str = "__credentials__";
 
 /// Set the master password for the credential vault.
 ///
-/// Initializes the vault identity if not already done, or unlocks if it exists.
+/// Initializes the vault identity if none exists. When an identity already
+/// exists this CHANGES its password (requires the vault to be unlocked,
+/// e.g. via OS keychain auto-unlock) — previously it attempted an unlock
+/// with the new password, which always failed (issue #25).
 #[tauri::command]
 #[tracing::instrument(skip(password, state))]
 pub async fn credential_set_master_password(
@@ -23,9 +26,14 @@ pub async fn credential_set_master_password(
     let mut manager = state.vault_manager.lock().await;
 
     if manager.has_identity().await {
-        // Identity exists, just unlock
+        if manager.is_locked() {
+            return Err(
+                "Vault is locked. Unlock it with your current method first, then set a new password."
+                    .into(),
+            );
+        }
         manager
-            .unlock(&password)
+            .change_password(&password)
             .await
             .map_err(|e| e.to_string())?;
     } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -580,6 +580,108 @@ pub fn run() {
             tracing::info!("App data dir: {:?}", data_dir);
             app.manage(AppState::new());
 
+            // Build application menu (macOS menu bar).
+            // We replace the default Copy/Paste menu items with custom ones that
+            // have NO keyboard accelerators.  The default ones (Cmd+C / Cmd+V)
+            // consume the key events before xterm's attachCustomKeyEventHandler
+            // can see them, which breaks clipboard in the terminal.
+            //
+            // When the user clicks Edit > Copy / Paste we emit an event to the
+            // webview; the webview forwards it to the active terminal.
+            #[cfg(desktop)]
+            {
+                use tauri::menu::{
+                    MenuBuilder, SubmenuBuilder, MenuItemBuilder, PredefinedMenuItem,
+                };
+                use tauri::Emitter;
+
+                let app_name = "Reach";
+
+                // --- Reach menu ---
+                let about = PredefinedMenuItem::about(app, Some("About Reach"), None)?;
+                let services = PredefinedMenuItem::services(app, None)?;
+                let separator1 = PredefinedMenuItem::separator(app)?;
+                let hide = PredefinedMenuItem::hide(app, Some("Hide Reach"))?;
+                let hide_others = PredefinedMenuItem::hide_others(app, None)?;
+                let show_all = PredefinedMenuItem::show_all(app, None)?;
+                let separator2 = PredefinedMenuItem::separator(app)?;
+                let quit = PredefinedMenuItem::quit(app, Some("Quit Reach"))?;
+                let reach_menu = SubmenuBuilder::new(app, app_name)
+                    .item(&about)
+                    .item(&services)
+                    .item(&separator1)
+                    .item(&hide)
+                    .item(&hide_others)
+                    .item(&show_all)
+                    .item(&separator2)
+                    .item(&quit)
+                    .build()?;
+
+                // --- File menu ---
+                let file_menu = SubmenuBuilder::new(app, "File")
+                    .item(&PredefinedMenuItem::close_window(app, Some("Close Window"))?)
+                    .build()?;
+
+                // --- Edit menu (custom Copy/Paste WITHOUT accelerators) ---
+                let copy_item = MenuItemBuilder::with_id("copy", "Copy").build(app)?;
+                let paste_item = MenuItemBuilder::with_id("paste", "Paste").build(app)?;
+                let cut_item = PredefinedMenuItem::cut(app, None)?;
+                let select_all = PredefinedMenuItem::select_all(app, None)?;
+                let edit_menu = SubmenuBuilder::new(app, "Edit")
+                    .item(&copy_item)
+                    .item(&paste_item)
+                    .item(&cut_item)
+                    .separator()
+                    .item(&select_all)
+                    .build()?;
+
+                // --- View menu ---
+                let view_menu = SubmenuBuilder::new(app, "View")
+                    .item(&PredefinedMenuItem::fullscreen(app, None)?)
+                    .build()?;
+
+                // --- Window menu ---
+                let minimize = PredefinedMenuItem::minimize(app, None)?;
+                let zoom = PredefinedMenuItem::maximize(app, None)?;
+                let window_menu = SubmenuBuilder::new(app, "Window")
+                    .item(&minimize)
+                    .item(&zoom)
+                    .build()?;
+
+                // --- Help menu ---
+                let help_menu = SubmenuBuilder::new(app, "Help")
+                    .build()?;
+
+                let app_menu = MenuBuilder::new(app)
+                    .item(&reach_menu)
+                    .item(&file_menu)
+                    .item(&edit_menu)
+                    .item(&view_menu)
+                    .item(&window_menu)
+                    .item(&help_menu)
+                    .build()?;
+
+                app.set_menu(app_menu)?;
+
+                // Route menu-bar Copy/Paste clicks to the webview so the active
+                // terminal can handle them.
+                app.on_menu_event(move |app_handle, event| {
+                    match event.id().as_ref() {
+                        "copy" => {
+                            if let Some(w) = app_handle.get_webview_window("main") {
+                                let _ = w.emit("menu-copy", ());
+                            }
+                        }
+                        "paste" => {
+                            if let Some(w) = app_handle.get_webview_window("main") {
+                                let _ = w.emit("menu-paste", ());
+                            }
+                        }
+                        _ => {}
+                    }
+                });
+            }
+
             // Build system tray
             #[cfg(desktop)]
             {

--- a/src-tauri/src/vault/error.rs
+++ b/src-tauri/src/vault/error.rs
@@ -11,6 +11,9 @@ pub enum VaultError {
     #[error("Identity already exists")]
     IdentityAlreadyExists,
 
+    #[error("No password is set for this identity. Unlock via system keychain, then set a password in Settings > Security.")]
+    PasswordNotSet,
+
     #[error("Vault not found: {0}")]
     NotFound(String),
 

--- a/src-tauri/src/vault/manager.rs
+++ b/src-tauri/src/vault/manager.rs
@@ -160,11 +160,12 @@ impl VaultManager {
             tracing::warn!("Failed to store key in keychain: {}", e);
         }
 
-        // Encrypt secret key with password for backup
+        // Encrypt secret key with password for backup and persist it —
+        // without this, password unlock is impossible (issue #25).
         let password_kek = derive_kek_from_password(password.as_bytes(), &salt)?;
-        let (_encrypted_key, _nonce) = encrypt_with_password(&password_kek, secret_key.as_bytes())?;
+        let (encrypted_key, nonce) = encrypt_with_password(&password_kek, secret_key.as_bytes())?;
 
-        self.save_identity(&salt).await?;
+        self.save_identity(&salt, Some((encrypted_key, nonce))).await?;
         tracing::info!("init_identity: saved identity file");
 
         // Create internal vaults
@@ -202,6 +203,9 @@ impl VaultManager {
         salt.copy_from_slice(&salt_bytes);
 
         // Decrypt secret key with password
+        if stored.encrypted_key.is_empty() || stored.nonce.is_empty() {
+            return Err(VaultError::PasswordNotSet);
+        }
         let encrypted_key = BASE64
             .decode(&stored.encrypted_key)
             .map_err(|e| VaultError::SerializationError(e.to_string()))?;
@@ -262,6 +266,48 @@ impl VaultManager {
         self.reopen_user_vaults().await?;
 
         Ok(true)
+    }
+
+    /// Change the password that protects the identity's secret key.
+    ///
+    /// Requires an unlocked manager. The salt is intentionally kept: it also
+    /// feeds the secret-key-derived KEK that encrypts every vault, so a new
+    /// salt would invalidate all existing vault data. Only the
+    /// password-encrypted copy of the secret key is re-encrypted.
+    ///
+    /// This is also the recovery path for identities created before the fix
+    /// for issue #25, where the password-encrypted key was never persisted:
+    /// unlock via OS keychain, then set a password here.
+    pub async fn change_password(&mut self, new_password: &str) -> Result<(), VaultError> {
+        let identity = self.identity.as_ref().ok_or(VaultError::Locked)?;
+        let secret_key_bytes = identity.secret_key().to_bytes();
+
+        let identity_path = self.app_dir.join("vault_identity.json");
+        if !identity_path.exists() {
+            return Err(VaultError::IdentityNotInitialized);
+        }
+        let data = tokio::fs::read_to_string(&identity_path).await?;
+        let stored: StoredIdentity = serde_json::from_str(&data)?;
+
+        let salt_bytes = BASE64
+            .decode(&stored.salt)
+            .map_err(|e| VaultError::SerializationError(e.to_string()))?;
+        if salt_bytes.len() != 32 {
+            return Err(VaultError::InvalidKeyLength {
+                expected: 32,
+                got: salt_bytes.len(),
+            });
+        }
+        let mut salt = [0u8; 32];
+        salt.copy_from_slice(&salt_bytes);
+
+        let password_kek = derive_kek_from_password(new_password.as_bytes(), &salt)?;
+        let (encrypted_key, nonce) =
+            encrypt_with_password(&password_kek, &secret_key_bytes)?;
+
+        self.save_identity(&salt, Some((encrypted_key, nonce))).await?;
+        tracing::info!("change_password: identity re-encrypted with new password");
+        Ok(())
     }
 
     /// Auto-unlock using OS keychain (TLS-style, no password needed).
@@ -427,7 +473,7 @@ impl VaultManager {
             if salt_bytes.len() == 32 {
                 let mut salt = [0u8; 32];
                 salt.copy_from_slice(&salt_bytes);
-                self.save_identity(&salt).await?;
+                self.save_identity(&salt, None).await?;
             }
         }
 
@@ -828,19 +874,28 @@ impl VaultManager {
     }
 
     /// Save identity to file.
-    async fn save_identity(&self, salt: &[u8; 32]) -> Result<(), VaultError> {
+    /// Save identity. `password_key` carries fresh password-encrypted secret
+    /// key material `(encrypted_key_b64, nonce_b64)` when setting or changing
+    /// the password; otherwise the previously stored material is preserved.
+    async fn save_identity(
+        &self,
+        salt: &[u8; 32],
+        password_key: Option<(String, String)>,
+    ) -> Result<(), VaultError> {
         let identity = self.identity.as_ref().ok_or(VaultError::Locked)?;
         let public_key = identity.public_key;
 
-        // For encrypted_key and nonce, we need the password-encrypted version
-        // which should already be stored. Read existing if available.
+        // For encrypted_key and nonce, we need the password-encrypted version.
+        // Use fresh material when provided; otherwise keep what is on disk.
         let identity_path = self.app_dir.join("vault_identity.json");
-        let (encrypted_key, nonce) = if identity_path.exists() {
+        let (encrypted_key, nonce) = if let Some((ek, n)) = password_key {
+            (ek, n)
+        } else if identity_path.exists() {
             let data = tokio::fs::read_to_string(&identity_path).await?;
             let stored: StoredIdentity = serde_json::from_str(&data)?;
             (stored.encrypted_key, stored.nonce)
         } else {
-            // New identity - encrypted_key should be set during init
+            // New identity without password material yet.
             (String::new(), String::new())
         };
 
@@ -875,7 +930,7 @@ impl VaultManager {
             if salt_bytes.len() == 32 {
                 let mut salt = [0u8; 32];
                 salt.copy_from_slice(&salt_bytes);
-                self.save_identity(&salt).await?;
+                self.save_identity(&salt, None).await?;
             }
         }
         Ok(())
@@ -1881,7 +1936,7 @@ impl VaultManager {
             tracing::warn!("Failed to store key in keychain: {}", e);
         }
 
-        self.save_identity(&salt).await?;
+        self.save_identity(&salt, None).await?;
 
         // Create internal vaults
         self.ensure_internal_vaults().await?;
@@ -2512,4 +2567,80 @@ fn get_key_from_keychain(user_uuid: &str) -> Result<Vec<u8>, VaultError> {
     BASE64
         .decode(&password)
         .map_err(|e| VaultError::SerializationError(e.to_string()))
+}
+
+#[cfg(test)]
+mod password_tests {
+    use super::*;
+
+    fn tmp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "reach-vault-test-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Regression test for issue #25: the password-encrypted secret key was
+    /// computed at identity init but discarded, so password unlock never
+    /// worked after a restart — only OS-keychain auto-unlock did.
+    #[tokio::test]
+    async fn password_roundtrip_and_change_issue_25() {
+        let dir = tmp_dir("roundtrip");
+
+        // Init identity with a password.
+        let mut mgr = VaultManager::new(dir.clone());
+        mgr.init_identity("hunter2hunter2").await.unwrap();
+        mgr.lock();
+
+        // Fresh manager (simulated restart): unlock with the init password.
+        let mut mgr2 = VaultManager::new(dir.clone());
+        assert!(
+            mgr2.unlock("hunter2hunter2").await.unwrap(),
+            "unlock with the init password must succeed (issue #25)"
+        );
+
+        // Wrong password must not unlock.
+        mgr2.lock();
+        let mut mgr3 = VaultManager::new(dir.clone());
+        let bad = mgr3.unlock("wrong-password").await;
+        assert!(bad.is_err() || matches!(bad, Ok(false)));
+
+        // Change password while unlocked, then the new one works.
+        let mut mgr4 = VaultManager::new(dir.clone());
+        mgr4.unlock("hunter2hunter2").await.unwrap();
+        mgr4.change_password("second-password").await.unwrap();
+        mgr4.lock();
+
+        let mut mgr5 = VaultManager::new(dir.clone());
+        assert!(mgr5.unlock("second-password").await.unwrap());
+        mgr5.lock();
+
+        // The old password no longer works.
+        let mut mgr6 = VaultManager::new(dir.clone());
+        let old = mgr6.unlock("hunter2hunter2").await;
+        assert!(old.is_err() || matches!(old, Ok(false)));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Changing the password requires an unlocked manager.
+    #[tokio::test]
+    async fn change_password_requires_unlock() {
+        let dir = tmp_dir("locked-change");
+        let mut mgr = VaultManager::new(dir.clone());
+        mgr.init_identity("initial-pass-123").await.unwrap();
+        mgr.lock();
+
+        let err = mgr
+            .change_password("whatever-else")
+            .await
+            .expect_err("change_password while locked must fail");
+        assert!(matches!(err, VaultError::Locked));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/lib/components/terminal/Terminal.svelte
+++ b/src/lib/components/terminal/Terminal.svelte
@@ -377,7 +377,21 @@
 				return false;
 			}
 
+			// macOS: Cmd+C copies the selection (Cmd is never used as a terminal
+			// control key, so this is safe on all platforms).
+			if (event.metaKey && event.key === 'c' && term.hasSelection()) {
+				event.preventDefault();
+				void copySelection(term);
+				return false;
+			}
+
 			if (event.ctrlKey && event.key === 'v') {
+				event.preventDefault();
+				void pasteFromClipboard(term);
+				return false;
+			}
+
+			if (event.metaKey && event.key === 'v') {
 				event.preventDefault();
 				void pasteFromClipboard(term);
 				return false;
@@ -524,6 +538,19 @@
 			}
 			termEl.addEventListener('wheel', onWheel, { passive: false });
 
+			// Listen for menu-bar Copy/Paste events (Rust emits these when the
+			// user clicks Edit > Copy / Paste since the menu items have no
+			// keyboard accelerators — Cmd+C / Cmd+V are handled by xterm's
+			// attachCustomKeyEventHandler below).
+			let unlistenMenuCopy: UnlistenFn | undefined;
+			let unlistenMenuPaste: UnlistenFn | undefined;
+			listen('menu-copy', () => {
+				if (term.hasSelection()) void copySelection(term);
+			}).then((fn) => { unlistenMenuCopy = fn; });
+			listen('menu-paste', () => {
+				void pasteFromClipboard(term);
+			}).then((fn) => { unlistenMenuPaste = fn; });
+
 			// Note: selection deliberately does NOT auto-copy. Copy is explicit
 			// via Ctrl+C (with a selection) or right-click — so drag-selecting
 			// never clobbers the clipboard. (xterm has no copy-on-select here.)
@@ -553,6 +580,8 @@
 			unregisterBufferReader(bufferId);
 			unlistenData?.();
 			unlistenExit?.();
+			unlistenMenuCopy?.();
+			unlistenMenuPaste?.();
 			resizeObserver?.disconnect();
 			term.dispose();
 			terminal = undefined;


### PR DESCRIPTION
Fixes #25.

**Root cause:** `init_identity` encrypted the secret key with the user's password, then **discarded the ciphertext** (`_encrypted_key`) and `save_identity` wrote empty strings into `vault_identity.json`. `unlock(password)` therefore always failed — only OS-keychain auto-unlock worked. That matches the report exactly: auto-unlock works, but setting a password "doesn't work" on Windows and Arch, and on systems without a usable keychain the user is stuck on the backup-key prompt.

**Changes**
- `save_identity` accepts fresh password-key material; `init_identity` persists the encrypted secret key instead of dropping it
- New `VaultManager::change_password` — re-encrypts the secret key under a new password. Salt is kept (it also feeds the secret-key-derived vault KEK; rotating it would invalidate all vault data). Doubles as the recovery path for existing identities with empty `encrypted_key`: unlock via keychain, then set a password
- `credential_set_master_password` now actually changes the password when an identity exists (previously it attempted `unlock(new_password)`, which always failed); locked vault → clear error
- `unlock()` returns a clear `PasswordNotSet` error instead of a decode/decrypt failure on empty ciphertext

**Tests** (full suite 26/26 green)
- `password_roundtrip_and_change_issue_25`: init → simulated restart → password unlock succeeds; wrong password rejected; change_password → new works, old rejected
- `change_password_requires_unlock`

Verified on a real install whose `vault_identity.json` has the bug signature (empty `encrypted_key`/`nonce`) — same state as affected users.