### PR TITLE
Fix corrupted terminal output, and make keychain failures diagnosable

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod session;
 pub mod sftp;
 pub mod ssh;
 pub mod state;
+pub mod text;
 pub mod tofu;
 pub mod toolchain;
 pub mod tunnel;

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -216,6 +216,9 @@ fn pty_reader_loop(
     let data_event = format!("pty-data-{}", id);
     let exit_event = format!("pty-exit-{}", id);
     let mut buf = [0u8; 4096];
+    // Reads cut at 4096 bytes regardless of character boundaries, so decode
+    // as a stream rather than per chunk.
+    let mut decoder = crate::text::Utf8Stream::new();
 
     loop {
         match reader.read(&mut buf) {
@@ -225,7 +228,10 @@ fn pty_reader_loop(
                 break;
             }
             Ok(n) => {
-                let payload = String::from_utf8_lossy(&buf[..n]).to_string();
+                let payload = decoder.push(&buf[..n]);
+                if payload.is_empty() {
+                    continue;
+                }
                 if let Err(e) = app_handle.emit(&data_event, payload) {
                     tracing::error!("Failed to emit '{}': {}", data_event, e);
                     break;
@@ -236,6 +242,10 @@ fn pty_reader_loop(
                 break;
             }
         }
+    }
+
+    if let Some(tail) = decoder.flush() {
+        let _ = app_handle.emit(&data_event, tail);
     }
 
     // Notify frontend that the PTY has exited.

--- a/src-tauri/src/ssh/client.rs
+++ b/src-tauri/src/ssh/client.rs
@@ -913,6 +913,7 @@ pub async fn exec_on_connection(
     channel.exec(true, command).await
         .map_err(|e| SshError::ChannelError(format!("{}", e)))?;
     let mut output = String::new();
+    let mut decoder = crate::text::Utf8Stream::new();
     let mut got_eof = false;
     let mut got_exit = false;
     loop {
@@ -924,7 +925,7 @@ pub async fn exec_on_connection(
 
         match msg {
             Ok(Some(ChannelMsg::Data { ref data })) => {
-                output.push_str(&String::from_utf8_lossy(data));
+                output.push_str(&decoder.push(data));
             }
             Ok(Some(ChannelMsg::ExtendedData { .. })) => {
                 // stderr — skip
@@ -963,6 +964,8 @@ pub async fn exec_on_connection_with_exit_code(
     let mut stdout = String::new();
     let mut stderr = String::new();
     let mut exit_code: i32 = -1;
+    let mut out_decoder = crate::text::Utf8Stream::new();
+    let mut err_decoder = crate::text::Utf8Stream::new();
     let mut got_eof = false;
     let mut got_exit = false;
 
@@ -974,10 +977,10 @@ pub async fn exec_on_connection_with_exit_code(
 
         match msg {
             Ok(Some(ChannelMsg::Data { ref data })) => {
-                stdout.push_str(&String::from_utf8_lossy(data));
+                stdout.push_str(&out_decoder.push(data));
             }
             Ok(Some(ChannelMsg::ExtendedData { ref data, .. })) => {
-                stderr.push_str(&String::from_utf8_lossy(data));
+                stderr.push_str(&err_decoder.push(data));
             }
             Ok(Some(ChannelMsg::Eof)) => {
                 got_eof = true;
@@ -1026,6 +1029,8 @@ pub async fn exec_on_connection_streaming(
     let mut exit_code: i32 = -1;
     let mut got_eof = false;
     let mut got_exit = false;
+    let mut out_decoder = crate::text::Utf8Stream::new();
+    let mut err_decoder = crate::text::Utf8Stream::new();
 
     loop {
         let msg = tokio::time::timeout(
@@ -1035,7 +1040,10 @@ pub async fn exec_on_connection_streaming(
 
         match msg {
             Ok(Some(ChannelMsg::Data { ref data })) => {
-                let text = String::from_utf8_lossy(data).to_string();
+                let text = out_decoder.push(data);
+                if text.is_empty() {
+                    continue;
+                }
                 let _ = app_handle.emit(
                     &output_event,
                     StreamingOutputEvent {
@@ -1046,7 +1054,10 @@ pub async fn exec_on_connection_streaming(
                 );
             }
             Ok(Some(ChannelMsg::ExtendedData { ref data, .. })) => {
-                let text = String::from_utf8_lossy(data).to_string();
+                let text = err_decoder.push(data);
+                if text.is_empty() {
+                    continue;
+                }
                 let _ = app_handle.emit(
                     &output_event,
                     StreamingOutputEvent {
@@ -1289,6 +1300,13 @@ async fn ssh_session_task(
     let data_event = format!("ssh-data-{}", connection_id);
     let exit_event = format!("ssh-exit-{}", connection_id);
 
+    // Remote output arrives in arbitrary packet-sized chunks, so a
+    // multi-byte character can straddle two of them. Decode as a stream,
+    // not per chunk. stdout and stderr are independent streams and each
+    // needs its own carry-over.
+    let mut out_decoder = crate::text::Utf8Stream::new();
+    let mut err_decoder = crate::text::Utf8Stream::new();
+
     // Hold remote output until the frontend signals it's listening
     // (SessionCommand::Ready) so the motd/banner emitted before the terminal
     // mounts isn't dropped. A safety cap flushes anyway if Ready never arrives.
@@ -1324,10 +1342,16 @@ async fn ssh_session_task(
             msg = channel.wait() => {
                 match msg {
                     Some(ChannelMsg::Data { ref data }) => {
-                        deliver!(String::from_utf8_lossy(data).to_string());
+                        let text = out_decoder.push(data);
+                        if !text.is_empty() {
+                            deliver!(text);
+                        }
                     }
                     Some(ChannelMsg::ExtendedData { ref data, .. }) => {
-                        deliver!(String::from_utf8_lossy(data).to_string());
+                        let text = err_decoder.push(data);
+                        if !text.is_empty() {
+                            deliver!(text);
+                        }
                     }
                     Some(ChannelMsg::ExitStatus { exit_status }) => {
                         tracing::info!("SSH '{}' exited with status {}", connection_id, exit_status);
@@ -1374,6 +1398,12 @@ async fn ssh_session_task(
                 }
             }
         }
+    }
+
+    // The stream ended; surface any bytes held back mid-character rather
+    // than swallowing them.
+    for tail in [out_decoder.flush(), err_decoder.flush()].into_iter().flatten() {
+        let _ = app_handle.emit(&data_event, &tail);
     }
 
     if let Err(e) = app_handle.emit(&exit_event, ()) {

--- a/src-tauri/src/text.rs
+++ b/src-tauri/src/text.rs
@@ -1,0 +1,133 @@
+//! Text decoding helpers for byte streams that arrive in arbitrary chunks.
+
+/// Incremental UTF-8 decoder.
+///
+/// SSH packets and PTY reads split wherever the transport decides, so a
+/// multi-byte character routinely straddles two chunks. Decoding each chunk
+/// independently with `String::from_utf8_lossy` turns that character into
+/// U+FFFD permanently — the bytes are already gone by the time the rest of the
+/// character arrives. When the mangled bytes land inside an escape sequence
+/// the terminal parser can also stall waiting for a terminator that never
+/// comes, which reads as output lagging a keystroke behind.
+///
+/// This holds an incomplete trailing character back and prepends it to the
+/// next chunk. The held tail is at most 3 bytes, since that is the longest
+/// prefix of a UTF-8 character that can be incomplete.
+#[derive(Debug, Default)]
+pub struct Utf8Stream {
+    pending: Vec<u8>,
+}
+
+impl Utf8Stream {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decode `chunk`, carrying any incomplete trailing character forward to
+    /// the next call. Returns the text that is complete now, which is empty
+    /// when the chunk was nothing but the start of a character.
+    pub fn push(&mut self, chunk: &[u8]) -> String {
+        let mut buf = std::mem::take(&mut self.pending);
+        buf.extend_from_slice(chunk);
+
+        match std::str::from_utf8(&buf) {
+            Ok(s) => s.to_string(),
+            Err(e) => {
+                let good = e.valid_up_to();
+                // error_len() == None means the bytes from `good` onward are a
+                // valid prefix of a character that simply has not finished
+                // arriving — hold them. Some(_) means they are genuinely
+                // invalid, so emit lossily now rather than holding garbage
+                // that will never become valid.
+                if e.error_len().is_none() {
+                    let out = String::from_utf8_lossy(&buf[..good]).into_owned();
+                    self.pending = buf[good..].to_vec();
+                    out
+                } else {
+                    String::from_utf8_lossy(&buf).into_owned()
+                }
+            }
+        }
+    }
+
+    /// Emit any held bytes because the stream ended mid-character. They cannot
+    /// be completed now, so they decode lossily.
+    pub fn flush(&mut self) -> Option<String> {
+        if self.pending.is_empty() {
+            return None;
+        }
+        let out = String::from_utf8_lossy(&self.pending).into_owned();
+        self.pending.clear();
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_ascii_passes_through() {
+        let mut s = Utf8Stream::new();
+        assert_eq!(s.push(b"hello"), "hello");
+        assert!(s.flush().is_none());
+    }
+
+    /// The regression: a character split across two chunks must survive.
+    #[test]
+    fn character_split_across_chunks_is_not_corrupted() {
+        // U+00E9 (e-acute) is 0xC3 0xA9.
+        let mut s = Utf8Stream::new();
+        assert_eq!(s.push(&[b'a', 0xC3]), "a", "incomplete tail must be held");
+        assert_eq!(s.push(&[0xA9, b'b']), "\u{e9}b", "held byte must be rejoined");
+        assert!(s.flush().is_none());
+
+        // Compare against the old per-chunk behavior, which loses it.
+        assert_eq!(String::from_utf8_lossy(&[b'a', 0xC3]), "a\u{fffd}");
+    }
+
+    #[test]
+    fn three_byte_character_split_at_every_offset() {
+        // U+2500 BOX DRAWINGS LIGHT HORIZONTAL is 0xE2 0x94 0x80 — the kind of
+        // character an OpenWrt banner is full of.
+        let ch = [0xE2u8, 0x94, 0x80];
+        for split in 1..ch.len() {
+            let mut s = Utf8Stream::new();
+            let mut out = s.push(&ch[..split]);
+            out.push_str(&s.push(&ch[split..]));
+            assert_eq!(out, "\u{2500}", "split at {} lost the character", split);
+        }
+    }
+
+    #[test]
+    fn four_byte_character_split() {
+        // U+1F600, 0xF0 0x9F 0x98 0x80.
+        let ch = [0xF0u8, 0x9F, 0x98, 0x80];
+        let mut s = Utf8Stream::new();
+        assert_eq!(s.push(&ch[..2]), "");
+        assert_eq!(s.push(&ch[2..]), "\u{1f600}");
+    }
+
+    #[test]
+    fn genuinely_invalid_bytes_are_not_held_forever() {
+        let mut s = Utf8Stream::new();
+        // 0xFF can never start a valid character, so it must be emitted now.
+        assert_eq!(s.push(&[0xFF]), "\u{fffd}");
+        assert!(s.flush().is_none(), "nothing should be held");
+    }
+
+    #[test]
+    fn flush_emits_a_dangling_partial_character() {
+        let mut s = Utf8Stream::new();
+        assert_eq!(s.push(&[0xE2, 0x94]), "");
+        assert_eq!(s.flush(), Some("\u{fffd}".to_string()));
+        assert!(s.flush().is_none());
+    }
+
+    #[test]
+    fn held_tail_never_exceeds_three_bytes() {
+        let mut s = Utf8Stream::new();
+        s.push(&[0xF0, 0x9F, 0x98]);
+        assert!(s.pending.len() <= 3);
+    }
+}

--- a/src-tauri/src/vault/error.rs
+++ b/src-tauri/src/vault/error.rs
@@ -65,6 +65,9 @@ pub enum VaultError {
     #[error("Keychain key missing - your data exists but the encryption key was lost from the OS keychain. Use 'Import Identity' to restore from backup.")]
     KeychainKeyMissing,
 
+    #[error("No OS keychain available ({0}). On Linux this usually means no Secret Service provider is running - start gnome-keyring-daemon or kwallet, or unlock the vault with your password instead.")]
+    KeychainUnavailable(String),
+
     #[error("Access denied: {0}")]
     AccessDenied(String),
 

--- a/src-tauri/src/vault/manager.rs
+++ b/src-tauri/src/vault/manager.rs
@@ -157,7 +157,10 @@ impl VaultManager {
 
         // Store secret key in OS keychain
         if let Err(e) = store_key_in_keychain(&user_uuid, secret_key.as_bytes()) {
-            tracing::warn!("Failed to store key in keychain: {}", e);
+            tracing::error!(
+                "Could not store the vault key in the OS keychain: {}. Auto-unlock will not work on the next launch; your password is the only way back in.",
+                e
+            );
         }
 
         // Encrypt secret key with password for backup and persist it —
@@ -246,7 +249,10 @@ impl VaultManager {
 
         // Store in keychain for auto-unlock
         if let Err(e) = store_key_in_keychain(&stored.user_uuid, secret_key.as_bytes()) {
-            tracing::warn!("Failed to store key in keychain: {}", e);
+            tracing::error!(
+                "Could not store the vault key in the OS keychain: {}. Auto-unlock will not work on the next launch.",
+                e
+            );
         }
 
         // Load personal sync config
@@ -1933,7 +1939,10 @@ impl VaultManager {
 
         // Store in keychain
         if let Err(e) = store_key_in_keychain(&user_uuid, secret_key.as_bytes()) {
-            tracing::warn!("Failed to store key in keychain: {}", e);
+            tracing::error!(
+                "Could not store the vault key in the OS keychain: {}. Auto-unlock will not work on the next launch; your password is the only way back in.",
+                e
+            );
         }
 
         self.save_identity(&salt, None).await?;
@@ -2557,12 +2566,15 @@ fn store_key_in_keychain(user_uuid: &str, key: &[u8]) -> Result<(), VaultError> 
 fn get_key_from_keychain(user_uuid: &str) -> Result<Vec<u8>, VaultError> {
     let entry = keyring::Entry::new("reach-vault", user_uuid)
         .map_err(|e| VaultError::KeychainError(e.to_string()))?;
-    let password = entry.get_password().map_err(|e| {
-        if e.to_string().contains("No matching entry") {
-            VaultError::KeychainKeyMissing
-        } else {
-            VaultError::KeychainError(e.to_string())
+    let password = entry.get_password().map_err(|e| match e {
+        keyring::Error::NoEntry => VaultError::KeychainKeyMissing,
+        keyring::Error::NoStorageAccess(ref inner) => {
+            VaultError::KeychainUnavailable(inner.to_string())
         }
+        keyring::Error::PlatformFailure(ref inner) => {
+            VaultError::KeychainUnavailable(inner.to_string())
+        }
+        other => VaultError::KeychainError(other.to_string()),
     })?;
     BASE64
         .decode(&password)


### PR DESCRIPTION
Addresses all three open issues. Full reasoning is in the commit messages.

## #32 and #31 - terminal output

Output was decoded with from_utf8_lossy() on each chunk as it arrived. SSH packets and PTY reads split wherever the transport decides, so a multi-byte character routinely straddles two chunks, and decoding them independently replaces it with U+FFFD permanently.

That is the missed character in #32: an OpenWrt banner is full of three-byte box-drawing characters, and any one landing on a chunk boundary is destroyed.

It likely also explains #31. When the corruption falls inside an escape sequence, xterm's parser waits for a terminator that was mangled away and stalls until more bytes arrive, so the next keypress produces the echo that unblocks it and what appears is the previous output, one keystroke late.

Fix: a text::Utf8Stream holding an incomplete trailing character (max 3 bytes) and prepending it to the next chunk. Applied to the interactive SSH session (separate carry-over per stream), the local PTY reader, both exec paths, and the streaming exec used for Ansible and OpenTofu. Wire format unchanged, so no frontend change and no payload-size regression.

## #30 - cannot decrypt saved data

The data-loss half is already fixed on main and simply has not been released. The issue-25 work persists the password-encrypted secret key, which was previously computed and discarded, so before it the OS keychain was the only way into a vault. On Linux with no Secret Service running, the key went nowhere at init (logged at warn and ignored) and the vault became unopenable on the next launch. Cutting a release is the real fix.

This PR adds diagnosability, since the failure currently looks like corruption and the panel offers reinitialising, which destroys everything. Keychain errors are now matched by type rather than by message text, a missing keyring backend reports as a distinct KeychainUnavailable, and a failed keychain write at init is logged at error level saying auto-unlock will not work.

## Verification

Unit tests cover splits at every offset of 2, 3 and 4 byte characters, invalid bytes not being held, and flush.

NOT COMPILE-VERIFIED: no Rust toolchain on the machine I worked from, and CI only builds Rust on release tags. Please run cargo test before merging. The two svelte-check errors here are pre-existing on main and fixed by the marketplace PR.