### PR TITLE
Retire stale BETA/NEW badges, and make the shell work on small screens

### DIFF
--- a/src/lib/components/layout/AppShell.svelte
+++ b/src/lib/components/layout/AppShell.svelte
@@ -182,9 +182,13 @@
 <style>
 	.app-shell {
 		display: grid;
-		grid-template-rows: 38px 36px 1fr 24px;
+		grid-template-rows: var(--titlebar-h, 38px) var(--tabbar-h, 36px) 1fr var(--statusbar-h, 24px);
 		width: 100vw;
 		height: 100vh;
+		/* dvh tracks the *visible* viewport, so the status bar is not pushed
+		   under the on-screen keyboard or the mobile browser chrome. Declared
+		   after the vh fallback for engines that do not support it. */
+		height: 100dvh;
 		/* Keep the title/status bars clear of the device status & navigation
 		   bars on mobile. `env(safe-area-inset-*)` is 0 on desktop, so this is
 		   a no-op there (requires viewport-fit=cover, set in app.html). */
@@ -201,7 +205,18 @@
 
 	.main-content {
 		flex: 1;
+		min-width: 0;
 		overflow: auto;
 		background-color: var(--color-bg-primary);
+	}
+
+	/* Phones in landscape, and short desktop windows, have very little vertical
+	   room. Trim the fixed chrome so the terminal keeps a usable number of rows. */
+	@media (max-height: 480px) {
+		.app-shell {
+			--titlebar-h: 32px;
+			--tabbar-h: 30px;
+			--statusbar-h: 20px;
+		}
 	}
 </style>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -42,7 +42,7 @@
 		} catch {}
 	}
 
-	let sections = $derived<Array<{ id: Section; label: string; icon: string; beta?: boolean; isNew?: boolean }>>([
+	let sections = $derived<Array<{ id: Section; label: string; icon: string }>>([
 		{
 			id: 'sessions',
 			label: t('sidebar.sessions'),
@@ -61,15 +61,12 @@
 		{
 			id: 'snippets',
 			label: t('sidebar.snippets'),
-			icon: 'M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2M9 2h6a1 1 0 011 1v1a1 1 0 01-1 1H9a1 1 0 01-1-1V3a1 1 0 011-1z',
-			isNew: true
+			icon: 'M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2M9 2h6a1 1 0 011 1v1a1 1 0 01-1 1H9a1 1 0 01-1-1V3a1 1 0 011-1z'
 		},
 		{
 			id: 'plugins',
 			label: t('sidebar.plugins'),
-			icon: 'M13 2L3 14h9l-1 8 10-12h-9l1-8z',
-			beta: true,
-			isNew: true
+			icon: 'M13 2L3 14h9l-1 8 10-12h-9l1-8z'
 		}
 	]);
 
@@ -111,7 +108,7 @@
 	}
 </script>
 
-<aside class="sidebar" class:no-transition={dragging} style:width="{collapsed ? COLLAPSED_WIDTH : sidebarWidth}px">
+<aside class="sidebar" class:collapsed class:no-transition={dragging} style:width="{collapsed ? COLLAPSED_WIDTH : sidebarWidth}px">
 	<nav class="sidebar-nav">
 		{#each sections as section (section.id)}
 			<button
@@ -133,12 +130,6 @@
 
 				{#if !collapsed}
 					<span class="nav-label">{section.label}</span>
-					{#if section.beta || section.isNew}
-						<span class="badge-group">
-							{#if section.beta}<span class="beta-badge">BETA</span>{/if}
-							{#if section.isNew}<span class="new-badge">NEW</span>{/if}
-						</span>
-					{/if}
 				{/if}
 			</button>
 		{/each}
@@ -207,6 +198,33 @@
 		flex-shrink: 0;
 	}
 
+	/* The width is remembered in localStorage and applied inline, so a sidebar
+	   dragged to 600px on a desktop would still be 600px on a phone, leaving no
+	   room for the terminal. Cap it against the viewport instead of the stored
+	   value; the inline width still wins whenever it is the smaller of the two. */
+	@media (max-width: 900px) {
+		.sidebar:not(.collapsed) {
+			max-width: 55vw;
+		}
+	}
+
+	@media (max-width: 600px) {
+		.sidebar:not(.collapsed) {
+			max-width: 75vw;
+		}
+	}
+
+	/* Finger-sized hit targets where there is no mouse. */
+	@media (pointer: coarse) {
+		.nav-btn {
+			padding: 9px 10px;
+		}
+
+		.resize-handle {
+			width: 12px;
+		}
+	}
+
 	.sidebar-nav {
 		display: flex;
 		flex-direction: column;
@@ -248,38 +266,8 @@
 		text-overflow: ellipsis;
 	}
 
-	.badge-group {
-		margin-left: auto;
-		display: flex;
-		gap: 3px;
-		flex-shrink: 0;
-	}
 
-	.beta-badge {
-		padding: 1px 4px;
-		font-size: 0.5rem;
-		font-weight: 700;
-		letter-spacing: 0.05em;
-		color: rgb(255, 159, 10);
-		background-color: rgba(255, 159, 10, 0.12);
-		border: 1px solid rgba(255, 159, 10, 0.25);
-		border-radius: 3px;
-		line-height: 1.2;
-		flex-shrink: 0;
-	}
 
-	.new-badge {
-		padding: 1px 4px;
-		font-size: 0.5rem;
-		font-weight: 700;
-		letter-spacing: 0.05em;
-		color: rgb(48, 209, 88);
-		background-color: rgba(48, 209, 88, 0.12);
-		border: 1px solid rgba(48, 209, 88, 0.25);
-		border-radius: 3px;
-		line-height: 1.2;
-		flex-shrink: 0;
-	}
 
 	.sidebar-content {
 		flex: 1;

--- a/src/lib/components/layout/TabBar.svelte
+++ b/src/lib/components/layout/TabBar.svelte
@@ -245,4 +245,21 @@
 		background-color: var(--color-bg-secondary);
 		color: var(--color-text-primary);
 	}
+
+	/* 120px per tab overflows a phone at three tabs. Let them compress; the
+	   label already truncates with an ellipsis. */
+	@media (max-width: 600px) {
+		.tab {
+			min-width: 84px;
+			max-width: 140px;
+			padding: 0 6px 0 8px;
+		}
+	}
+
+	@media (pointer: coarse) {
+		.tab-close {
+			width: 24px;
+			height: 24px;
+		}
+	}
 </style>

--- a/src/lib/components/plugin/PluginPanel.svelte
+++ b/src/lib/components/plugin/PluginPanel.svelte
@@ -169,6 +169,7 @@
 			onclick={() => (activeTab = 'marketplace')}
 		>
 			{t('plugin.tab_marketplace')}
+			<span class="new-badge">NEW</span>
 		</button>
 	</div>
 
@@ -251,6 +252,10 @@
 	}
 
 	.tab-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 5px;
 		flex: 1;
 		padding: 7px 10px;
 		font-family: var(--font-sans);
@@ -266,6 +271,16 @@
 		transition:
 			color var(--duration-default) var(--ease-default),
 			border-color var(--duration-default) var(--ease-default);
+	}
+
+	.new-badge {
+		padding: 1px 4px;
+		font-size: 0.5rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: #fff;
+		background-color: var(--color-accent);
+		border-radius: 3px;
 	}
 
 	.tab-btn:hover {

--- a/src/lib/components/sessions/QuickConnect.svelte
+++ b/src/lib/components/sessions/QuickConnect.svelte
@@ -179,7 +179,6 @@
 			<label class="jump-toggle">
 				<input type="checkbox" bind:checked={jumpEnabled} disabled={connecting} />
 				<span class="jump-toggle-text">{t('session.jump_host_enable')}</span>
-				<span class="beta-badge">BETA</span>
 			</label>
 
 			{#if jumpEnabled}
@@ -414,16 +413,6 @@
 		color: var(--color-text-primary);
 	}
 
-	.beta-badge {
-		padding: 1px 5px;
-		font-size: 0.5rem;
-		font-weight: 700;
-		letter-spacing: 0.05em;
-		color: #fff;
-		background: linear-gradient(135deg, #ff6b35, #f7c948);
-		border-radius: 3px;
-		line-height: 1.4;
-	}
 
 	.jump-hint {
 		margin: 0;

--- a/src/lib/components/sessions/SessionEditor.svelte
+++ b/src/lib/components/sessions/SessionEditor.svelte
@@ -283,7 +283,6 @@
 			<label class="jump-toggle">
 				<input type="checkbox" bind:checked={jumpEnabled} disabled={saving} />
 				<span class="jump-toggle-text">{t('session.jump_host_enable')}</span>
-				<span class="beta-badge">BETA</span>
 			</label>
 
 			{#if jumpEnabled}
@@ -675,16 +674,6 @@
 		color: var(--color-text-primary);
 	}
 
-	.beta-badge {
-		padding: 1px 5px;
-		font-size: 0.5rem;
-		font-weight: 700;
-		letter-spacing: 0.05em;
-		color: #fff;
-		background: linear-gradient(135deg, #ff6b35, #f7c948);
-		border-radius: 3px;
-		line-height: 1.4;
-	}
 
 	.jump-hint {
 		margin: 0;

--- a/src/lib/components/sessions/SessionList.svelte
+++ b/src/lib/components/sessions/SessionList.svelte
@@ -579,7 +579,6 @@
 					/>
 				</svg>
 				{t('session.import_ssh_config')}
-				<span class="beta-badge">BETA</span>
 			</button>
 		</div>
 
@@ -840,16 +839,6 @@
 		gap: 4px;
 	}
 
-	.beta-badge {
-		padding: 1px 4px;
-		font-size: 0.45rem;
-		font-weight: 700;
-		letter-spacing: 0.05em;
-		color: #fff;
-		background: linear-gradient(135deg, #ff6b35, #f7c948);
-		border-radius: 3px;
-		line-height: 1.4;
-	}
 
 	.quick-connect-btn,
 	.save-session-btn {


### PR DESCRIPTION
Two related bits of UI work.

## Badges

Jump hosts, SSH-config import, snippets and plugins have shipped across several releases now. A badge that never comes off stops meaning "this is new" and starts reading as "this is unfinished".

Removed: sidebar NEW on Snippets, BETA and NEW on Plugins, BETA on the Jump Host toggle in both Quick Connect and the session editor, and BETA on Import SSH config. The beta/isNew fields are gone from the sidebar section model entirely, not just hidden in markup, and the orphaned CSS rules go with them.

Added NEW to the Marketplace tab, which genuinely is new.

These were hardcoded strings rather than i18n keys, so there are no locale changes and no conflict with the marketplace PR.

## Small screens

Android is a shipped target, but every media query in the app lived in the Ansible and OpenTofu panels. The shell itself had none and was laid out purely for a desktop window.

- Sidebar width is remembered in localStorage and applied inline, so one dragged to 600px on a desktop stayed 600px on a phone with nothing left for the terminal. Clamped to 55vw under 900px and 75vw under 600px. An author max-width still constrains an inline width, so the stored value keeps winning when it is smaller.
- - Terminal tabs had min-width 120px, so three overflowed a phone. They compress to 84px under 600px; labels already ellipsize.
- - The shell used 100vh, which on mobile ignores browser chrome and the on-screen keyboard and pushes the status bar out of view. Now 100dvh with the vh fallback kept first.
- - Fixed chrome of 38 + 36 + 24px ate a third of a landscape phone. Under 480px tall it trims to 32 + 30 + 20 via custom properties on the grid.
- - Larger hit areas for the sidebar nav buttons, the resize handle and the tab close button under (pointer: coarse), inert on desktop.
## Verification

svelte-check: no new errors and no unused CSS selectors. Checked against the running dev server in a browser - the badges are visibly gone from the sidebar, all six new rules parse with correct Svelte scoping, none match at desktop size, and a max-width clamp does override the inline width (600px to 200px in a probe).

I could not shrink the browser window itself to photograph the breakpoints live, so the narrow layouts are verified by rule evaluation rather than by eye. Worth a look on a real device before release.

I deliberately did not restyle anything - colours, spacing and typography are unchanged. Those are your aesthetic calls, and I would rather propose than impose. Happy to go further if you tell me the direction.