### PR TITLE
Fix the session list hanging on its spinner forever

### DIFF
--- a/src/lib/components/sessions/SessionList.svelte
+++ b/src/lib/components/sessions/SessionList.svelte
@@ -14,7 +14,7 @@
 	import { t } from '$lib/state/i18n.svelte';
 	import { untrack } from 'svelte';
 	import { positionMenu } from '$lib/utils/positionMenu';
-	import { vaultState, checkState, initIdentity, refreshVaults, importIdentity } from '$lib/state/vault.svelte';
+	import { vaultState, checkState, initIdentity, importIdentity } from '$lib/state/vault.svelte';
 
 	let showQuickConnect = $state(false);
 	let showEditor = $state(false);
@@ -475,17 +475,34 @@
 		}
 	}
 
-	// Load sessions and vaults on mount (auto-unlock via OS keychain)
+	// Load sessions and vaults on mount (auto-unlock via OS keychain).
+	//
+	// Every path out of here must clear `loading`. Without the catch, a single
+	// rejected vault IPC left the spinner up forever and the session list never
+	// appeared — the panel looked like it was loading endlessly. That is easy to
+	// hit in normal use: open a session, use the file manager (which reads
+	// credentials out of the vault), then switch back to Sessions, which
+	// remounts this component and re-runs the whole check against a vault that
+	// is busy.
+	//
+	// checkState() already refreshes the vault list once it unlocks, so the
+	// second refreshVaults() that used to be here was a redundant round-trip and
+	// one more thing that could reject.
 	$effect(() => {
 		untrack(() => {
-			checkState().then(async () => {
-				if (!vaultState.locked) {
-					await refreshVaults();
-					await loadSessions();
-				} else {
+			checkState()
+				.then(async () => {
+					if (!vaultState.locked) {
+						await loadSessions();
+					} else {
+						loading = false;
+					}
+				})
+				.catch((err) => {
+					console.error('Failed to load the session list:', err);
+					addToast(String(err), 'error');
 					loading = false;
-				}
-			});
+				});
 		});
 	});
 </script>

--- a/src/lib/state/vault.svelte.ts
+++ b/src/lib/state/vault.svelte.ts
@@ -176,9 +176,21 @@ export async function checkState(): Promise<void> {
 	}
 
 	if (!vaultState.locked) {
-		vaultState.userUuid = await vaultIpc.getUserUuid();
-		vaultState.publicKey = await vaultIpc.getPublicKey();
-		await refreshVaults();
+		// Identity metadata and the vault list are not needed to consider the
+		// vault open. Letting one of them reject would throw away the fact that
+		// the unlock succeeded and leave callers believing the whole check
+		// failed — which is what stranded the session list on its spinner.
+		try {
+			vaultState.userUuid = await vaultIpc.getUserUuid();
+			vaultState.publicKey = await vaultIpc.getPublicKey();
+		} catch (err) {
+			console.error('Vault unlocked but identity metadata is unavailable:', err);
+		}
+		try {
+			await refreshVaults();
+		} catch (err) {
+			console.error('Vault unlocked but the vault list could not be read:', err);
+		}
 		restoreLocalSettingsFromVault();
 	}
 }


### PR DESCRIPTION
Opening a session, using the file manager, then switching back to Sessions could leave the panel loading indefinitely.

Switching sidebar sections remounts SessionList, which re-runs its mount effect. That effect called `checkState().then(...)` with no `.catch()`, and `loading` is only cleared inside `loadSessions()` or on the locked branch. So any rejection anywhere in the chain skipped both and left `loading = true` permanently — the spinner never stopped and the list never rendered.

There is plenty to reject. checkState() awaits five vault IPC calls and only wraps autoUnlock() in a try/catch; every Tauri command returning Err rejects the JS promise. Using the file manager first makes this materially more likely, since it reads credentials out of the same vault.

VaultPanel already guarded its checkState() call with .catch(), so this was a known hazard that SessionList simply missed.

- Added the missing .catch(): it logs, surfaces the error as a toast instead of a silent hang, and always clears `loading`. An error the user can see beats a spinner that lies, and beats an empty list that claims there are no sessions.
- Made the identity-metadata and vault-list fetches in checkState() non-fatal. Neither is required to consider the vault open, and letting either reject discarded a successful unlock and failed the whole check.
- Dropped the duplicate refreshVaults() from the effect. checkState() already refreshes the vault list when it unlocks, so it was a redundant round-trip and one more thing that could reject.

svelte-check: 0 errors, 0 warnings.